### PR TITLE
[fastapi-firebase] AGENTS.md / Cursor rules の整理と issue テンプレート追加

### DIFF
--- a/.cursor/rules/status_codes.md
+++ b/.cursor/rules/status_codes.md
@@ -1,3 +1,3 @@
-- Never use raw numeric HTTP status codes (e.g., 200, 404).
-- Always use FastAPI status helpers (e.g. status.    assert response.status_code == status.HTTP_200_OK).
+- Never use raw numeric HTTP status codes (e.g., 200, 404) in application or test code when FastAPI provides a named constant.
+- Always use FastAPI `status` helpers (e.g. `from fastapi import status` and `assert response.status_code == status.HTTP_200_OK`).
 - Reject code that violates this rule and rewrite it.

--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -1,0 +1,43 @@
+name: バグ報告
+description: 不具合や期待と異なる動作を報告する
+title: "[bug] "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        再現手順と環境を書けるだけ具体的に書いてください。
+  - type: textarea
+    id: summary
+    attributes:
+      label: 概要
+      description: 何が問題か、一行で
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: 再現手順
+      description: ステップ、または再現用リクエスト例
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期待する動作
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: 実際の動作
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: 環境
+      description: OS、Python / uv のバージョン、Docker の有無など
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/02_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/02_feature_request.yml
@@ -1,0 +1,31 @@
+name: 機能提案・改善
+description: 新機能やドキュメント・DX の改善を提案する
+title: "[feat] "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        背景と受け入れ条件が分かると検討しやすいです。
+  - type: textarea
+    id: problem
+    attributes:
+      label: 背景 / 課題
+      description: なぜ必要か、どんな痛みがあるか
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: 提案内容
+      description: 実装案・APIの形・挙動の希望があれば
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: 受け入れ条件（任意）
+      description: 完了とみなす条件
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ Without Docker, use the same checks as CI: `uv run pytest` (and ruff via `uv run
 ## 6. PR instructions
 
 - Branch name: `feat/<short-description>` (optionally include the GitHub issue id, e.g. `feat/123-short-description`).
-- Title format: `[fastapi-firebase] <Title>`
+- Title format: `<Title>`
 - Before committing: run `make format` and `make test` when using Docker; otherwise run the equivalent `uv run` commands above.
 
 These practices keep agent-assisted work aligned with FastAPI, uv, and this repo’s Docker setup.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,46 @@
-## Testing instructions
-- Find the CI plan in the .github/workflows folder.
-- Run `uv run pytest` to run every check defined for that package.
+# AGENTS Guidelines for This Repository
 
-## PR instructions
-- Branch name must start at feat/<Title>
-- Title format: [<project_name>] <Title>
-- Always run `make format` and `make test` before committing.
+This repository contains a FastAPI application under `app/`. When using an agent (e.g. Cursor), follow these guidelines so development stays consistent with CI and Docker.
+
+## 1. Development server
+
+- **Docker (recommended):** `make prepare` starts the stack; the API is served at http://127.0.0.1:8000 with `--reload` (see `docker-compose.yaml`).
+- **Local (uv):** `uv run uvicorn app.main:app --reload --host 0.0.0.0 --port 8000` so the port matches compose unless you intentionally use another (e.g. debugger on 8080 in `.vscode/launch.json`).
+
+After dependency changes, restart the server so the process picks up the updated environment.
+
+## 2. Dependencies
+
+If you add or change dependencies:
+
+1. Update `pyproject.toml` and refresh the lockfile (`uv lock` or `uv add <package>`).
+2. Commit `uv.lock` with your code changes.
+
+## 3. Coding conventions
+
+- Prefer Python (`.py`) for new code.
+- HTTP status codes: follow `.cursor/rules/status_codes.md` (use `fastapi.status` constants in app and test code, not raw numeric literals).
+
+## 4. Useful commands
+
+`make format` and `make test` run **inside** the `app` container via Docker Compose (`docker compose exec`). Use `make prepare` first so the container is up.
+
+| Command       | Purpose                    |
+| ------------- | -------------------------- |
+| `make format` | Ruff check (fix) + format  |
+| `make test`   | Pytest in the container    |
+
+Without Docker, use the same checks as CI: `uv run pytest` (and ruff via `uv run ruff` if needed).
+
+## 5. Testing instructions
+
+- Find the CI plan in `.github/workflows/`.
+- Run `uv run pytest` to match the workflow’s test step.
+
+## 6. PR instructions
+
+- Branch name: `feat/<short-description>` (optionally include the GitHub issue id, e.g. `feat/123-short-description`).
+- Title format: `[fastapi-firebase] <Title>`
+- Before committing: run `make format` and `make test` when using Docker; otherwise run the equivalent `uv run` commands above.
+
+These practices keep agent-assisted work aligned with FastAPI, uv, and this repo’s Docker setup.


### PR DESCRIPTION
## 概要
issue #2 を踏まえ、エージェント向けドキュメントと Cursor ルールをリポジトリ実態（FastAPI・uv・Docker）に合わせ、GitHub の issue テンプレートを追加します。

## 変更内容
- **AGENTS.md**: Next.js の誤記を削除し、開発サーバー（ポート 8000 / compose との整合）、依存関係（`uv.lock`）、`make` が Docker 前提であること、PR のタイトル形式 `[fastapi-firebase] <Title>` を明記
- **.cursor/rules/status_codes.md**: 例文の崩れを修正し、ルールを一文で明確化
- **.github/ISSUE_TEMPLATE/**: バグ報告・機能提案の Issue フォーム（YAML）と `config.yml`（空の issue も許可）

## テスト
- `uv run pytest`
- `uv run ruff check .` / `uv run ruff format --check .`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (agent guidelines, Cursor rule wording) plus GitHub issue form templates; no runtime code paths are modified.
> 
> **Overview**
> Updates `AGENTS.md` to match the repo’s FastAPI/uv/Docker workflow (dev server commands/port, dependency+lockfile expectations, and PR conventions).
> 
> Clarifies the Cursor rule in `.cursor/rules/status_codes.md` to consistently require `fastapi.status` constants instead of numeric literals.
> 
> Adds GitHub Issue Forms for bug reports and feature requests under `.github/ISSUE_TEMPLATE/` (and enables blank issues via `config.yml`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d7a292dc07e85ee8663a38c8671c0288afb8271. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->